### PR TITLE
Duplicate show handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from connections import search_shows, episodes_list
+from connections import search_shows, episodes_list, show_info
 from random import choice
 
 
@@ -17,10 +17,10 @@ def list_shows(search_results):
         # print("{}. {}".format(index, show['name']))
         print("{}. {} - {}".format(index, show['name'], show['show_id']))
     show_index = int(
-        input("Type the number of the show you would like to select from the list: ")
+        input("Type the number of the show you would like to select from the list: ").strip()
     ) - 1
     if search_results[show_index]:
-        random_episode(search_results[show_index]['show_id'], search_results[show_index]['name'])
+        preview_show(search_results, search_results[show_index]['show_id'])
     else:
         print("Please try again with a number from the list.")
         list_shows(search_results)
@@ -49,4 +49,23 @@ Type 'show' for new show | 'ep' for new episode | 'exit' to exit app
         pass
 
 
-show_search_prompt()
+def preview_show(search_results, show_id):
+    show = show_info(show_id)
+    user_input = input("""
+    {name} | Premiere Date: {premiered}
+    Description: {summary}
+    To pick a random episode from this show, type 'r'.
+    To go back to the search results, type 's'.
+    """.format(
+        name = show['name'],
+        premiered = show['premiered'],
+        summary = show['summary'],
+    ))
+    if user_input.lower() == 'r':
+        random_episode(show_id, show['name'])
+    else:
+        list_shows(search_results)
+
+
+if __name__ == '__main__':
+    show_search_prompt()

--- a/app.py
+++ b/app.py
@@ -51,16 +51,13 @@ Type 'show' for new show | 'ep' for new episode | 'exit' to exit app
 
 def preview_show(search_results, show_id):
     show = show_info(show_id)
-    user_input = input("""
-    {name} | Premiere Date: {premiered}
-    Description: {summary}
-    To pick a random episode from this show, type 'r'.
-    To go back to the search results, type 's'.
-    """.format(
+    print("{name} | Premiere Date: {premiered}".format(
         name = show['name'],
         premiered = show['premiered'],
-        summary = show['summary'],
     ))
+    print("Description: {}".format(show['summary']))
+    print("To pick a random episode from this show, type 'r'.")
+    user_input = input("To go back to the search results, type 's'.")
     if user_input.lower() == 'r':
         random_episode(show_id, show['name'])
     else:

--- a/app.py
+++ b/app.py
@@ -14,8 +14,7 @@ def show_search_prompt():
 def list_shows(search_results):
     print("Search results:")
     for index, show in enumerate(search_results, 1):
-        # print("{}. {}".format(index, show['name']))
-        print("{}. {} - {}".format(index, show['name'], show['show_id']))
+        print("{}. {}".format(index, show['name']))
     show_index = int(
         input("Type the number of the show you would like to select from the list: ").strip()
     ) - 1

--- a/app.py
+++ b/app.py
@@ -14,7 +14,8 @@ def show_search_prompt():
 def list_shows(search_results):
     print("Search results:")
     for index, show in enumerate(search_results, 1):
-        print("{}. {}".format(index, show['name']))
+        # print("{}. {}".format(index, show['name']))
+        print("{}. {} - {}".format(index, show['name'], show['show_id']))
     show_index = int(
         input("Type the number of the show you would like to select from the list: ")
     ) - 1

--- a/connections.py
+++ b/connections.py
@@ -5,6 +5,7 @@ import requests
 
 TVMAZE_URL = 'http://api.tvmaze.com/'
 SHOW_SEARCH = 'search/shows?q={}'
+SHOW_INFO = 'shows/{}'
 EPISODE_LIST = 'shows/{}/episodes'
 SPECIALS_QUERYSTRING = '?specials=1'
 
@@ -29,6 +30,25 @@ def search_shows(query):
             return None
     except Exception as e:
         print('Something went wrong retrieving the data.\nError: {}'.format(e))
+
+
+def show_info(show_id):
+    """Takes a show id and returns a dictionary
+    with information about the show"""
+    try:
+        response = requests.get(TVMAZE_URL + SHOW_INFO.format(show_id))
+        show_info = response.json()
+        if show_info['summary']:
+            summary = re.sub(r"\</?p\>", "", show_info['summary'])
+        else:
+            summary = 'none'
+        return {
+            'name': show_info['name'],
+            'premiered': show_info['premiered'],
+            'summary': summary,
+        }
+    except Exception as e:
+        print('Something went wrong retrieving the data\nError: {}'.format(e))
 
 
 def episodes_list(show_id, specials=False):


### PR DESCRIPTION
Fixes #1
 
When going through the todos in Issue #1, the following actions/discoveries were made:

1. There were no longer any shows breaking the app, and this may have been a temporary problem with the API.
1. I've added an additional step that lets you preview the air date and a description of the selected show before going back to the list of shows or forward to the randomly chosen episode
